### PR TITLE
Player inheritance fixes

### DIFF
--- a/ProjectFlightSchool/ProjectFlightSchool/PlayState.cpp
+++ b/ProjectFlightSchool/ProjectFlightSchool/PlayState.cpp
@@ -10,7 +10,8 @@ void PlayState::RemoteUpdate( IEventPtr newEvent )
 	{
 		std::shared_ptr<Event_Remote_Player_Joined> data = std::static_pointer_cast<Event_Remote_Player_Joined>( newEvent );
 		mRemotePlayers.push_back( new RemotePlayer() );
-		mRemotePlayers.at(mRemotePlayers.size() - 1)->Initialize( data->ID() );
+		mRemotePlayers.at(mRemotePlayers.size() - 1)->Initialize();
+		mRemotePlayers.at(mRemotePlayers.size() - 1)->RemoteInit( data->ID() );
 		printf( "Number of other players online: %d.\n", mRemotePlayers.size() );
 	}
 	else if ( newEvent->GetEventType() == Event_Remote_Player_Left::GUID )
@@ -49,7 +50,7 @@ void PlayState::KillRemotePlayer( IEventPtr newEvent )
 			}
 			else if ( data->ID() == mRemotePlayers.at(i)->GetID() )
 			{
-				mRemotePlayers.at(i)->RemotePlayerDie();
+				mRemotePlayers.at(i)->Die();
 
 				// Debug
 				OutputDebugString( L"> A Remote player has died." );

--- a/ProjectFlightSchool/ProjectFlightSchool/Player.cpp
+++ b/ProjectFlightSchool/ProjectFlightSchool/Player.cpp
@@ -91,8 +91,7 @@ void Player::Move( XMFLOAT3 direction )
 // Set current hp to 0 to avoid negative values and send event that player has died
 void Player::Die()
 {
-	mIsAlive = false;
-	mCurrentHp = 0.0f;
+	RemotePlayer::Die();
 	IEventPtr dieEv( new Event_Player_Died( mID ) );
 	EventManager::GetInstance()->QueueEvent( dieEv );
 }
@@ -167,6 +166,7 @@ void Player::Fire()
 
 HRESULT Player::Initialize()
 {
+	RemotePlayer::Initialize();
 	if( FAILED( Graphics::GetInstance()->LoadStatic3dAsset( "../Content/Assets/Robot/", "robotScenebody.pfs", mUpperBody.playerModel ) ) )
 		OutputDebugString( L"\nERROR\n" );
 
@@ -200,15 +200,6 @@ void Player::Release()
 Player::Player()
 	: RemotePlayer()
 {
-	mUpperBody.playerModel	= 0;
-	mUpperBody.position		= XMFLOAT3( 0.0f, 0.0f, 0.0f );
-	mUpperBody.direction	= XMFLOAT3( 0.0f, 0.0f, 0.0f );
-
-	mLowerBody.playerModel	= 0;
-	mLowerBody.position		= XMFLOAT3( 0.0f, 0.0f, 0.0f );
-	mLowerBody.direction	= XMFLOAT3( 0.0f, 0.0f, 0.0f );
-	mLowerBody.speed		= 0.0f;
-
 	mWeaponCoolDown			= 0.0f;
 }
 

--- a/ProjectFlightSchool/ProjectFlightSchool/Player.h
+++ b/ProjectFlightSchool/ProjectFlightSchool/Player.h
@@ -53,7 +53,7 @@ class Player: public RemotePlayer
 		HRESULT		Initialize();
 		void		Release();
 					Player();
-					~Player();
+		virtual		~Player();
 };
 #endif
 

--- a/ProjectFlightSchool/ProjectFlightSchool/RemotePlayer.cpp
+++ b/ProjectFlightSchool/ProjectFlightSchool/RemotePlayer.cpp
@@ -18,8 +18,14 @@ void RemotePlayer::LookAt( float rotation )
 {
 }
 
+void RemotePlayer::RemoteInit( unsigned int id )
+{
+	mID = id;
+	EventManager::GetInstance()->AddListener( &RemotePlayer::RemoteUpdate, this, Event_Remote_Player_Update::GUID );
+}
+
 // Kill remote player
-void RemotePlayer::RemotePlayerDie()
+void RemotePlayer::Die()
 {
 	mCurrentHp = 0.0f;
 	mIsAlive = false;
@@ -38,20 +44,18 @@ HRESULT RemotePlayer::Render( float deltaTime )
 	return S_OK;
 }
 
-HRESULT RemotePlayer::Initialize( unsigned int id )
+HRESULT RemotePlayer::Initialize()
 {
-	if ( FAILED( Graphics::GetInstance()->LoadStatic3dAsset( "../Content/Assets/Robot/", "robotScenebody.pfs", mUpperBody.playerModel) ) )
+	if( FAILED( Graphics::GetInstance()->LoadStatic3dAsset( "../Content/Assets/Robot/", "robotScenebody.pfs", mUpperBody.playerModel ) ) )
 		OutputDebugString( L"\nERROR\n" );
 
-	if ( FAILED( Graphics::GetInstance()->LoadStatic3dAsset( "../Content/Assets/Robot/", "robotScenelegs.pfs", mLowerBody.playerModel ) ) )
+	if( FAILED( Graphics::GetInstance()->LoadStatic3dAsset( "../Content/Assets/Robot/", "robotScenelegs.pfs", mLowerBody.playerModel ) ) )
 		OutputDebugString( L"\nERROR\n" );
 
-	mID					= id;
-	mUpperBody.position = XMFLOAT3( 10.0f, 0.0f, 10.0f );
-	mLowerBody.position = XMFLOAT3( 10.0f, 0.0f, 10.0f );
-	mLowerBody.speed	= 0.005f;
 
-	EventManager::GetInstance()->AddListener( &RemotePlayer::RemoteUpdate, this, Event_Remote_Player_Update::GUID );
+	mUpperBody.position	= XMFLOAT3( 3.0f, 0.0f, 0.0f );
+	mLowerBody.position	= XMFLOAT3( 3.0f, 0.0f, 0.0f );
+	mLowerBody.speed	= 15.0f;
 
 	return S_OK;
 }
@@ -64,17 +68,18 @@ void RemotePlayer::Release()
 RemotePlayer::RemotePlayer()
 {
 	mUpperBody.playerModel	= 0;
-	mUpperBody.position		= XMFLOAT3(0.0f, 0.0f, 0.0f);
-	mUpperBody.direction	= XMFLOAT3(0.0f, 0.0f, 0.0f);
+	mUpperBody.position		= XMFLOAT3( 0.0f, 0.0f, 0.0f );
+	mUpperBody.direction	= XMFLOAT3( 0.0f, 0.0f, 0.0f );
+
+	mLowerBody.playerModel	= 0;
+	mLowerBody.position		= XMFLOAT3( 0.0f, 0.0f, 0.0f );
+	mLowerBody.direction	= XMFLOAT3( 0.0f, 0.0f, 0.0f );
+	mLowerBody.speed		= 0.0f;
 
 	mIsAlive				= true;
 	mMaxHp					= 100.0f;
 	mCurrentHp				= mMaxHp;
-
-	mLowerBody.playerModel	= 0;
-	mLowerBody.position		= XMFLOAT3(0.0f, 0.0f, 0.0f);
-	mLowerBody.direction	= XMFLOAT3(0.0f, 0.0f, 0.0f);
-	mLowerBody.speed		= 0.0f;
+	mID						= 0;
 }
 
 RemotePlayer::~RemotePlayer()

--- a/ProjectFlightSchool/ProjectFlightSchool/RemotePlayer.h
+++ b/ProjectFlightSchool/ProjectFlightSchool/RemotePlayer.h
@@ -36,19 +36,20 @@ class RemotePlayer
 
 	// Member functions
 	private:
-		void RemoteUpdate( IEventPtr newEvent );
+		void		RemoteUpdate( IEventPtr newEvent );
 
 	protected:
-		void LookAt( float rotation );
+		void		LookAt( float rotation );
 
 	public:
-		void RemotePlayerDie();
-		int GetID() const;
-		HRESULT Render( float deltaTime );
-		HRESULT Initialize( unsigned int id );
-		void Release();
-		RemotePlayer();
-		~RemotePlayer();
+		void			RemoteInit( unsigned int id );
+		virtual void	Die();
+		int				GetID() const;
+		virtual HRESULT	Render( float deltaTime );
+		virtual HRESULT	Initialize();
+		void			Release();
+						RemotePlayer();
+		virtual			~RemotePlayer();
 };
 
 #endif


### PR DESCRIPTION
@sege12 @SvinSimpe 	
Did a few changes to the interaction between the Player-class and
the RemotePlayer-class to make the inheritance between these two classes
matter.

Changes I made:
Changed name of function RemotePlayerDie to just Die and used the inheritance between Player and RemotePlayer.
Added a function RemoteInit which is used to initialize things that are specific for RemotePlayers, such as adding an eventlistener and ID.
Removed stuff from Player-constructor since these are initialized in the constructor for RemotePlayer.
